### PR TITLE
migration logic changed

### DIFF
--- a/arbitrum/contracts/BondingCurve.sol
+++ b/arbitrum/contracts/BondingCurve.sol
@@ -29,6 +29,7 @@ contract BondingCurve is ReentrancyGuard {
 
     event TokenBuy(address _token, address _buyer, uint256 _value);
     event TokenSell(address _token, address _seller, uint256 _value);
+    event AwaitingForMigration(address _token, uint256 _timestamp);
     event MigrationToDEX(address _token, uint256 _erc721TokenId, uint256 _timestamp);
 
     error NotEnoughFunds();
@@ -129,6 +130,13 @@ contract BondingCurve is ReentrancyGuard {
     function _setMigrationOn() internal {
         tokenMigrated = true;
 
+        (bool success, ) = feeTaker.call(abi.encodeWithSignature("addToQueueForMigration()"));
+        require(success, "Migration failed");
+
+        emit AwaitingForMigration(address(token), tokenId, block.timestamp);
+    }
+
+    function migrateToDex() external {
         //creating and initializing pool
         uint24 poolFee = 5000;
         uint160 sqrtPriceX96 =  (MAX_PURCHASABLE / address(this).balance) ** 0.5;

--- a/arbitrum/contracts/Rampfun.sol
+++ b/arbitrum/contracts/Rampfun.sol
@@ -10,14 +10,25 @@ import "./RampToken.sol";
 contract Rampfun is Ownable, IERC721Receiver {
     address constant public UNISWAP_NFT_POS_MANAGER = 0xC36442b4a4522E871399CD717aBDD847Ab11FE88;
 
+    enum CurveStatus{ NotExisting, Created, Migrated }
+    mapping(address => CurveStatus) bondingCurves;
+    address[] public awaitingForMigration;
+
     event TokenDeployed(address _deployer, address _token, string _name, string _ticker);
 
     constructor() Ownable(msg.sender) {}
 
     receive() external payable {}
 
+    modifier onlyCurve() {
+        require(bondingCurves[msg.sender] == CurveStatus.Created);
+        _;
+    }
+
     function deployToken(string calldata _name, string calldata _ticker) public payable {
         RampToken token = new RampToken{value: msg.value}(_name, _ticker);
+
+        bondingCurves[address(token.bondingCurve)] = CurveStatus.Created;
 
         emit TokenDeployed(msg.sender, address(token), _name, _ticker);
     }
@@ -36,6 +47,20 @@ contract Rampfun is Ownable, IERC721Receiver {
             });
 
         (amount0, amount1) = nonfungiblePositionManager.collect(params);
+    }
+
+    function addToQueueForMigration() external onlyCurve {
+        awaitingForMigration.push(msg.sender);
+        bondingCurves[msg.sender] = CurveStatus.Migrated;
+    }
+
+    function migrateToDexBatch() external {
+        for (uint i = 0; i < awaitingForMigration.length; i++) {
+            (bool success, ) = awaitingForMigration[i].call(abi.encodeWithSignature("migrateToDex()"));
+            if (success) {
+                delete awaitingForMigration[i];
+            }
+        }
     }
 
     function onERC721Received(address operator, address, uint256 tokenId, bytes calldata) external override returns (bytes4) {


### PR DESCRIPTION
now the last user to buy informs the main contract that migration can happen and anyone can migrate the token instead of the last buyer who had to pay large commission.